### PR TITLE
chance <= 0 now allows chance to be random for each sample

### DIFF
--- a/openstl/simulation/generation.py
+++ b/openstl/simulation/generation.py
@@ -22,6 +22,14 @@ def update_array(array, mask, array_type, vmin=0.0, vmax=1.0, thickness=1, chanc
     Returns:
     - The final array and mask after updating.
     """
+
+    # if the user set the chance to None or <= 0, then each time we want to select a new
+    # random chance for just this call - creating a more diverse dataset - one that isn't
+    # just trained on 20% chance samples, for instance.
+    if chance is None or chance <= 0:
+        chance = np.random.random()
+        print(f"Chance was None (or <= 0) - so this initial condition we will use randomly chosen chance of: {chance}")
+
     rows, cols = array.shape
     if array_type == ArrayType.OUTLINE:
         array[:thickness, :] = array[-thickness:, :] = array[:, :thickness] = array[:, -thickness:] = vmax


### PR DESCRIPTION
This allows you to pass `--chance 0` to `generate_samples.py` in a new way.  Now, rather than all the samples you asked to generate all having 0% chance of having a cell "on", instead each call to generate a new sample now generates a new random chance, uniform 0 to 1, and uses _that_ chance for that sample gen.  This should create a more diverse dataset.